### PR TITLE
Make the managed identities available to sbot

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,9 @@ exports.init = function (sbot, config) {
         following: true,
         autofollow: true,
         contact: newKeys.id,
+      }, function(err, msg) {
+        cb(err, newKeys.id)
       })
-      cb(null, newKeys.id)
     },
     publishAs: function (opts, cb) {
       var id = opts.id

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs = require('fs')
 var ssbKeys = require('ssb-keys')
 var create = require('ssb-validate').create
 var ref = require('ssb-ref')
+var unbox = require('ssb-keys').unbox
 
 exports.name = 'identities'
 exports.version = '1.0.0'
@@ -25,17 +26,16 @@ exports.init = function (sbot, config) {
   }).map(function (file) {
     return ssbKeys.loadSync(path.join(dir, file))
   })
-  
+
   var keymap = {}
   var locks = {}
 
-  if(sbot.unboxers)
-    sbot.unboxers(function (content) {
-      for(var i = 0; i < keys.length; i++) {
-        var plaintext = _unbox(content, keys[i])
-        if(plaintext) return plaintext
-      }
-    })
+  sbot.addUnboxer(function(content) {
+    for(var i = 0;i < keys.length;i++) {
+      var plaintext = unbox(content, keys[i])
+      if(plaintext) return plaintext
+    }
+  });
 
   return {
     main: function () {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,12 @@ exports.init = function (sbot, config) {
       var filename = 'secret_'+leftpad(keys.length, 2, '0')+'.butt'
       var newKeys = ssbKeys.createSync(path.join(dir, filename))
       keys.push(newKeys)
+      sbot.publish({
+        type: 'contact',
+        following: true,
+        autofollow: true,
+        contact: newKeys.id,
+      })
       cb(null, newKeys.id)
     },
     publishAs: function (opts, cb) {


### PR DESCRIPTION
The additional identities need to be made available to the persistence layer ([secure-scuttlebot](https://github.com/ssbc/secure-scuttlebutt/) - [#PR213](https://github.com/ssbc/secure-scuttlebutt/pull/213)) so that it can be used to decode the feeds when reading. 