### PR TITLE
added reference to plugins documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,31 @@ sbot.identities.list(function (err, data) {
 
 ## API
 
-## identities.main (cb)
+### identities.main (cb)
 
 returns the main identity (sbot.id)
 
-## identities.list (cb)
+### identities.list (cb)
 
 returns the list of identities, with the main
 identity first.
 
-## identities.create (cb)
+### identities.create (cb)
 
 create a new identity, stored in `~/.ssb/identities/secret_[N].butt`
 where N is the left-padded number of this identity.
 returns the id of the newly created identity.
 
-## identities.publishAs({id:id, content: obj, private: boolean}, cb) 
+### identities.publishAs({id:id, content: obj, private: boolean}, cb) 
 
 publish a message as a specific identity.
 `id` must be provided and must be already in
 the identities list. If `private` is true,
 `content.recps` must be set. `recps` must contain
 the `id`.
+
+## More information about sbot plugins
+For more information about these type of plugins, refer to the [`plugins.md` in the `secret-stack` repository](https://github.com/ssbc/secret-stack/blob/master/plugins.md).
 
 ## License
 


### PR DESCRIPTION
The docs were great, I simply added a reference to the plugins.md file from secret-stack repository so that developers might learn more about how to make plugins.