### PR TITLE
Fix broken test: TypeError: sbot.addUnboxer is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "cont": "^1.0.3",
-    "scuttlebot": "^11.3.0",
+    "ssb-server": "^15.1.1",
     "tape": "^4.9.0"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 var tape = require('tape')
-var Scuttlebot = require('scuttlebot')
+var Scuttlebot = require('ssb-server')
 var cont = require('cont')
 var ssbKeys = require('ssb-keys')
 var other = ssbKeys.generate()
@@ -10,7 +10,7 @@ Scuttlebot
 var sbot = Scuttlebot({
   temp: 'identities',
   caps: {
-    sign: require('crypto')
+    shs: require('crypto')
       .randomBytes(32).toString('base64')
   }
 })


### PR DESCRIPTION
To reproduce the issue:
```
$ git clone https://github.com/ssbc/ssb-identities.git
$ cd ssb-identities
$ npm i
$ npm test

TypeError: sbot.addUnboxer is not a function
    at Object.exports.init (/home/austin/ssb-identities/index.js:40:8)
```



Updated dev-dependency from `"scuttlebot": "^11.3.0"`to `"ssb-server":"^15.1.1"`.

swapped `caps.sign` to `caps.shs` in tests.