### PR TITLE
Allow private messages to be published without publisher id

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ exports.init = function (sbot, config) {
       else if(!content.recps && opts.private)
         return cb(new Error('opts.private set, but content.recps not set'))
       else if(!!content.recps && opts.private) {
-        if(!Array.isArray(content.recps) || !~recps.indexOf(id))
-          return cb(new Error('content.recps must be an array containing publisher id:'+id+' was:'+JSON.stringify(recps)+' indexOf:'+recps.indexOf(id)))
+        if(!Array.isArray(content.recps) || !content.recps.length)
+          return cb(new Error('content.recps must be an array containing at least one id, was:'+JSON.stringify(recps)))
         content = ssbKeys.box(content, recps)
       }
 


### PR DESCRIPTION
For my app I need to be able to send private messages that only the receiver can read, I don't want even the sender to send the message again. This is totally possible with ssb-private but for some reason was blocked by ssb-identities